### PR TITLE
Add KC PHP UG to participating groups

### DIFF
--- a/docs/2017-participating-groups.md
+++ b/docs/2017-participating-groups.md
@@ -5,3 +5,4 @@ Please add your group below and keep the format and information as consistent as
 | Group name and location | Web and Social Media | Contact Name and Email |
 | :------ | :------ | :------ |
 | AtlantaPHP - Atlanta, GA, USA | [atlantaphp.org](http://atlantaphp.org)<br />[meetup.com/atlantaphp](http://www.meetup.com/atlantaphp)<br />[@AtlantaPHP](https://twitter.com/AtlantaPHP) | Chris Spruck - <chris@atlantaphp.org> |
+| Kansas City PHP UG - Kansas City, MO, USA | [kcpug.org](http://kcpug.org/)<br />[meetup.com/kcphpug](https://www.meetup.com/kcphpug/)<br />[@kcphpug](https://twitter.com/kcphpug) | Dan Holmes - <dan.holmes@gmail.com><br />John Kary - john at john kary dot net<br />Eric Poe - eric.poe@gmail.com |


### PR DESCRIPTION
UG leaders for KC PHP UG are mentioned in alpha order by last name. John Kary's email address is without special chars since that is the way he shows his email address on his website.