### PR TITLE
Correct some spelling errors

### DIFF
--- a/docs/_tutorials/creating-new-test-files.md
+++ b/docs/_tutorials/creating-new-test-files.md
@@ -105,7 +105,7 @@ var_dump(strtr("# hi all, I said hello world! #", $trans));
 string(32) "# hello All, I sAid hi planet! #"
 ```
 
-As you can see, the file is divided into several sections. The `TEST` section holds a one line title of the phpt test. This should be a simple description and shouldn't ever excede one line. If you need to write more explanation, add comments in the body of the test case. The phpt file's name is used when generating a `.php` file. The `FILE` section is used as the body of the `.php` file, so don't forget to open and close your PHP tags. The `EXPECT` section is the part used as a comparison to see if the test passes. It is a good idea to generate output with `var_dump()` calls.
+As you can see, the file is divided into several sections. The `TEST` section holds a one line title of the phpt test. This should be a simple description and shouldn't ever exceed one line. If you need to write more explanation, add comments in the body of the test case. The phpt file's name is used when generating a `.php` file. The `FILE` section is used as the body of the `.php` file, so don't forget to open and close your PHP tags. The `EXPECT` section is the part used as a comparison to see if the test passes. It is a good idea to generate output with `var_dump()` calls.
 
 ### PHPT structure details
 

--- a/docs/lead.md
+++ b/docs/lead.md
@@ -24,6 +24,6 @@ What are the important things you shouldn't miss when you want to organize a Tes
 
 ## On the event
 
-* Gather, decide whether your group wants to write tests for one specific extension/package/function or each attendee srites tests for whatever they feel comfortable with
+* Gather, decide whether your group wants to write tests for one specific extension/package/function or each attendee writes tests for whatever they feel comfortable with
 * Write tests
 * Commit the tests.

--- a/slides/README.rst
+++ b/slides/README.rst
@@ -13,8 +13,8 @@ mark-up language. reStructuredText is similar to Markdown but has a variety of
 other features that make it a bit more expressive. The Sphinx project has a
 great `primer on how to write reStructuredText`_. It's easy to use.
 
-We use `Hovercraft!`_ to convert this mark-up into presentatable HTML. Under the
-hood, Hovercraft! uses `impress.js`_ to create beautful presentations.
+We use `Hovercraft!`_ to convert this mark-up into presentable HTML. Under the
+hood, Hovercraft! uses `impress.js`_ to create beautiful presentations.
 Hovercraft! gives us the ability to easily accept contributions and track
 changes in a version control system. It's just plain text, and we like that.
 


### PR DESCRIPTION
This just corrects some minor spelling errors.

Since the diff highlighting is terrible in `creating-new-test-files.md`, I will point out that I changed "excede" to "exceed." The other spelling corrections are nicely highlighted in the diff views.