### PR TITLE
Allow hovercraft docker script to run in OSX & Linux

### DIFF
--- a/slides/present
+++ b/slides/present
@@ -13,7 +13,4 @@
 #     ./present presentation-name.rst folder-name
 #
 
-script=`realpath $0`
-scriptpath=`dirname $script`
-
-docker run -it --rm -p "9000:9000" -v $scriptpath:/presentation phpcommunity/hovercraft -t theme/template/template.cfg "$@"
+docker run -it --rm -p "9000:9000" -v "$PWD":/presentation phpcommunity/hovercraft -t theme/template/template.cfg "$@"


### PR DESCRIPTION
The `slides/present` script was failing in OSX because `realpath` is not a native OSX command.

One option for OSX users is to `brew install coreutils`, but this requires an extra step for those users.

A cleaner (I hope) option is included here.