### PR TITLE
Use rem units from CSS3 for lists so we can make deeper nested lists

### DIFF
--- a/slides/theme/presentation.css
+++ b/slides/theme/presentation.css
@@ -17,13 +17,8 @@ ul {
 }
 
 li {
-    font-size: 1.4em;
+    font-size: 2rem;
     margin-bottom: 0.6em;
-}
-
-li > ul > li {
-    font-size: inherit;
-    margin-bottom: inherit;
 }
 
 li:before {


### PR DESCRIPTION
I just saw [rem units](https://www.sitepoint.com/understanding-and-using-rem-units-in-css/) this weekend, so of course now I want to use them everywhere.

This bases the unit of measurement on the root html tag and not the parent. So no inheritance-addition of font sizes and such. This means that we can have deeply nested lists and not have funky font-size issues. Woo hoo!

Bonus, it works in every major browser, too!
https://caniuse.com/#search=rem