### PR TITLE
[pt-br] Fix broken link /pt-br/groups/2017

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,6 +15,10 @@ collections:
     output: true
     permalink: /:collection/:path/
     name: Tutorials
+  pt-br_groups:
+    output: true
+    permalink: /pt-br/groups/:path/
+    name: Grupos participantes
   pt-br_tutorials:
     output: true
     permalink: /pt-br/tutorials/:path/

--- a/docs/_pt-br_groups/2017.md
+++ b/docs/_pt-br_groups/2017.md
@@ -13,7 +13,7 @@ group to the list there.
 
 Os grupos abaixo fizeram suas inscrições nesta lista para demonstrar suas participações no PHP TestFest 2017. Cada grupo irá sediar um ou mais eventos durante o período de setembro a dezembro de 2017. Se você estiver interessado em fazer parte do PHP TestFest com um desses grupos, sinta-se à vontade para enviar um e-mail para um dos contatos do grupo escolhido ou acesse os links disponíveis para mais informações sobre suas atividades.
 
-Seu grupo está participando do PHP TestFest 2017? [Adicione seu grupo na lista!](https://github.com/phpcommunity/phptestfest.org/edit/master/docs/_data/groups/2017.yml)
+Seu grupo está participando do PHP TestFest 2017? [Adicione-o na lista!](https://github.com/phpcommunity/phptestfest.org/edit/master/docs/_data/groups/2017.yml)
 
 ---
 {:.major}


### PR DESCRIPTION
Evidence: https://validator.w3.org/checklink?uri=https%3A%2F%2Fphptestfest.org%2Fpt-br%2F&hide_redirects=on&hide_type=all&recursive=on&depth=2&check=Check#d2code_404

@rogeriopradoj solved that as in 7fba84a7b08a3c06fe7a31b55d4ffa501c96ed76, which means:

- create an specific collection in _config.yml
- adjust permalink to `/pt-br/groups/:path/`

Done
