### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "^0.9.2",
-        "mockery/mockery": "^0.9.9",
+        "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^5.7 || ^6.0",
         "squizlabs/php_codesniffer": "^3.0"
     },


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).