### PR TITLE
Fix build error in _data/groups/2017.yml

### DIFF
--- a/docs/_data/groups/2017.yml
+++ b/docs/_data/groups/2017.yml
@@ -313,7 +313,7 @@
   location: Sergipe, Brazil
   website: http://phpse.net/
   meetup: https://www.meetup.com/pt-BR/php-se/
-  telegram: @phpse
+  telegram: https://t.me/phpse
   contacts:
     - name: Renê Soares
       email: organizacao@phpse.net           


### PR DESCRIPTION
PHPSE community include Telegram handle directly, without a full url, which breaks build of _data/groups/2017.yml.

This way, build is fixed at least.

In future, would be a good thing to enable Telegram listing in groups page as well. Anyway it can be done afterwards.