### PR TITLE
Add Brazilian Telegram Group in pt-br sidebar and home page

### DIFF
--- a/docs/_data/pt_br_contact.yml
+++ b/docs/_data/pt_br_contact.yml
@@ -1,0 +1,10 @@
+#
+# PHP TestFest Contact Information
+#
+
+social:
+
+  telegram:
+    name: "@PHPTestFestBrasil no Telegram"
+    icon: fa-telegram
+    url: https://t.me/PHPTestFestBrasil

--- a/docs/_includes/pt-br_sidebar.html
+++ b/docs/_includes/pt-br_sidebar.html
@@ -36,8 +36,9 @@
             <header class="major">
                 <h2>Junte-se a nós</h2>
             </header>
-            <p>Nós adoraríamos que você se juntasse ao PHP TestFest. Para tirar dúvidas, mande-nos um email. Para se envolver, entre no nosso Google Group ou nos encontre no Slack do PHPC. Esperamos ver você em breve!</p>
+            <p>Nós adoraríamos que você se juntasse ao PHP TestFest. As comunidades brasileiras estão no Telegram. Para tirar dúvidas, mande-nos um email. Para se envolver, entre no nosso Google Group ou nos encontre no Slack do PHPC. Esperamos ver você em breve!</p>
             <ul class="contact">
+                <li class="{{ site.data.pt_br_contact.social.telegram.icon }}"><a href="{{ site.data.pt_br_contact.social.telegram.url }}">{{ site.data.pt_br_contact.social.telegram.name }}</a></li>
                 <li class="{{ site.data.contact.social.slack.icon }}"><a href="{{ site.data.contact.social.slack.url }}">{{ site.data.contact.social.slack.name }}</a></li>
                 <li class="{{ site.data.contact.social.google.icon }}"><a href="{{ site.data.contact.social.google.url }}">{{ site.data.contact.social.google.name }}</a></li>
                 <li class="fa-envelope-o"><a href="mailto:{{ site.data.contact.email }}">{{ site.data.contact.email }}</a></li>

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -60,6 +60,10 @@
                     <header id="header">
                         <a href="/" class="logo"><strong>PHP TestFest</strong> Sep - Dec, 2017</a>
                         <ul class="icons">
+                        {% if page.url contains 'pt-br' %}{% for item in site.data.pt_br_contact.social %}
+                        {% assign link = item[1] %}
+                            <li><a href="{{ link.url }}" class="icon {{ link.icon }}"><span class="label">{{ link.name }}</span></a></li>
+                        {% endfor %}{% endif %}
                         {% for item in site.data.contact.social %}
                         {% assign link = item[1] %}
                             <li><a href="{{ link.url }}" class="icon {{ link.icon }}"><span class="label">{{ link.name }}</span></a></li>


### PR DESCRIPTION
https://t.me/PHPTestFestBrasil on Telegram is the de facto communication resource
for several Brazilian User Groups/Communities members to speak in Brazilian
Portuguese, and is complimentary to all other global resources that we keep
sharing and encouraging members to use.